### PR TITLE
Add folder model and login protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# drop-box
+# Local Dropbox
+
+This project is a lightweight Django application for sharing files on a local network.  
+Uploaded files are stored on the server and can be browsed from any authenticated device on the same LAN.
+
+## Features
+
+* **File upload and download** – Upload multiple files and access them from the browser.
+* **Folder organisation** – Create folders and assign uploaded files to them.
+* **Image and video previews** – Thumbnails are generated for images and videos for quick browsing.
+* **Search** – Simple search by file title.
+* **Authentication** – Login is required to access any view.
+* **Refresh button** – Quickly reload the page to see new files.
+
+Additional functionality such as LAN device discovery or peer‑to‑peer sync is not included.
+
+## Development
+
+Create migrations and run the server:
+
+```bash
+python manage.py makemigrations
+python manage.py migrate
+python manage.py createsuperuser
+python manage.py runserver 0.0.0.0:8000
+```
+
+Media files are stored in the `media/` directory and static files in `staticfiles/`.

--- a/documents/admin.py
+++ b/documents/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Document
+from .models import Document, Folder
 
 
 class DocumentAdmin(admin.ModelAdmin):
@@ -7,3 +7,5 @@ class DocumentAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Document, DocumentAdmin)
+admin.site.register(Folder)
+

--- a/documents/forms.py
+++ b/documents/forms.py
@@ -1,14 +1,20 @@
 from django import forms
-from .models import Document
+from .models import Document, Folder
 
 
 class DocumentForm(forms.ModelForm):
     class Meta:
         model = Document
-        fields = ['title']  # Allow optional title on upload
+        fields = ['title', 'folder']  # Allow optional title and folder on upload
 
 
 class DocumentRenameForm(forms.ModelForm):
     class Meta:
         model = Document
         fields = ['title']
+
+
+class FolderForm(forms.ModelForm):
+    class Meta:
+        model = Folder
+        fields = ['name']

--- a/documents/migrations/0008_folder_and_size.py
+++ b/documents/migrations/0008_folder_and_size.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('documents', '0007_remove_document_device_info'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Folder',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=255)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='document',
+            name='folder',
+            field=models.ForeignKey(blank=True, null=True, on_delete=models.SET_NULL, related_name='documents', to='documents.folder'),
+        ),
+        migrations.AddField(
+            model_name='document',
+            name='size',
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+    ]

--- a/documents/templates/base.html
+++ b/documents/templates/base.html
@@ -13,11 +13,17 @@
   <a href="/">Home</a>
   <a href="/photos">photos</a>
   <a href="/videos">Video</a>
-    <a href="/others">Others</a>
+  <a href="/others">Others</a>
+  {% if user.is_authenticated %}
+  <a href="{% url 'logout' %}">Logout</a>
+  {% else %}
+  <a href="{% url 'login' %}">Login</a>
+  {% endif %}
   <form action="{% url 'search' %}" method="get" class="search-form">
     <input type="text" name="q" placeholder="Search" value="{{ request.GET.q }}">
     <button type="submit">Search</button>
   </form>
+  <button onclick="location.reload()">Refresh</button>
 </div>
 
     <main>
@@ -90,3 +96,5 @@
     </script>
 </body>
 </html>
+
+

--- a/documents/templates/create_folder.html
+++ b/documents/templates/create_folder.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Create Folder</h2>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Create</button>
+</form>
+{% endblock %}

--- a/documents/templates/login.html
+++ b/documents/templates/login.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/documents/templates/main.html
+++ b/documents/templates/main.html
@@ -6,9 +6,28 @@
     <form id="upload-form" method="post" action="{% url 'upload_file' %}" enctype="multipart/form-data">
         {% csrf_token %}
         {{ form.as_p }}
+        <label for="id_folder">Folder:</label>
+        <select name="folder" id="id_folder">
+            <option value="" selected>---</option>
+            {% for folder in folders %}
+            <option value="{{ folder.id }}">{{ folder.name }}</option>
+            {% endfor %}
+        </select>
+        <a href="{% url 'create_folder' %}">New Folder</a>
         <input type="file" name="file" multiple>
         <button type="submit">Upload</button>
     </form>
     <div id="progress-container"></div>
-</div>
+</div><h3>Uploaded Files</h3>
+<table>
+  <tr><th>Title</th><th>Folder</th><th>Size</th><th>Uploaded</th></tr>
+  {% for document in documents %}
+  <tr>
+    <td><a href="{% url 'document_detail' document.id %}">{{ document.title }}</a></td>
+    <td>{{ document.folder.name|default:'' }}</td>
+    <td>{{ document.size_display }}</td>
+    <td>{{ document.uploaded_at }}</td>
+  </tr>
+  {% endfor %}
+</table>
 <script src="{% static 'upload.js' %}"></script>{% endblock %}

--- a/documents/urls.py
+++ b/documents/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django.contrib.auth import views as auth_views
 from . import views
 
 urlpatterns = [
@@ -11,4 +12,7 @@ urlpatterns = [
     path('search/', views.search, name='search'),
     path('documents/<int:document_id>/delete/', views.delete_document, name='delete_document'),
     path('documents/<int:document_id>/rename/', views.rename_document, name='rename_document'),
+    path('folders/new/', views.create_folder, name='create_folder'),
+    path('login/', auth_views.LoginView.as_view(template_name='login.html'), name='login'),
+    path('logout/', auth_views.LogoutView.as_view(next_page='login'), name='logout'),
 ]

--- a/documents/views.py
+++ b/documents/views.py
@@ -1,25 +1,40 @@
-from .forms import DocumentForm, DocumentRenameForm
-from .models import Document
+from django.contrib.auth.decorators import login_required
+from .forms import DocumentForm, DocumentRenameForm, FolderForm
+from .models import Document, Folder
 from django.shortcuts import render, redirect
 from django.shortcuts import get_object_or_404
 from django.http import JsonResponse
 
 
+@login_required
 def main(request):
     if request.method == 'POST':
         files = request.FILES.getlist('file')
+        folder_id = request.POST.get('folder')
+        folder = Folder.objects.filter(id=folder_id).first() if folder_id else None
         for f in files:
-            document = Document(file=f)
+            document = Document(file=f, folder=folder)
             document.save()
         if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             return JsonResponse({'success': True})
         return redirect('home')
     else:
         form = DocumentForm()
+        folder_form = FolderForm()
         documents = Document.objects.all()
-    return render(request, 'main.html', {'form': form, 'documents': documents})
+        folders = Folder.objects.all()
+    return render(
+        request,
+        'main.html',
+        {
+            'form': form,
+            'documents': documents,
+            'folders': folders,
+            'folder_form': folder_form,
+        },
+    )
 
-
+@login_required
 def photos(request):
     # This regex matches files ending with .jpg, .jpeg, .png, or .gif (case-insensitive)
     photo_files_regex = r'.*\.(jpg|jpeg|png|gif)$'
@@ -27,12 +42,14 @@ def photos(request):
     return render(request, 'photos.html', {'documents': documents})
 
 
+@login_required
 def videos(request):
     video_files_regex = r'.*\.(mp4|mov|avi|mkv)$'  # Regular expression to match video file extensions
     documents = Document.objects.filter(file__iregex=video_files_regex)
     return render(request, 'videos.html', {'documents': documents})
 
 
+@login_required
 def others(request):
     # Combine photo and video regex patterns and exclude them
     not_photo_video_regex = r'.*\.(jpg|jpeg|png|gif|mp4|mov|avi|mkv)$'
@@ -40,6 +57,7 @@ def others(request):
     return render(request, 'others.html', {'documents': documents})
 
 
+@login_required
 def document_detail(request, document_id):
     document = get_object_or_404(Document, id=document_id)
 
@@ -61,6 +79,7 @@ def document_detail(request, document_id):
         'prev_document': prev_document,    })
 
 
+@login_required
 def search(request):
     query = request.GET.get('q', '')
     documents = Document.objects.filter(title__icontains=query) if query else []
@@ -70,6 +89,7 @@ def search(request):
     })
 
 
+@login_required
 def delete_document(request, document_id):
     document = get_object_or_404(Document, id=document_id)
     if request.method == 'POST':
@@ -80,6 +100,7 @@ def delete_document(request, document_id):
     return render(request, 'confirm_delete.html', {'document': document})
 
 
+@login_required
 def rename_document(request, document_id):
     document = get_object_or_404(Document, id=document_id)
     if request.method == 'POST':
@@ -93,3 +114,15 @@ def rename_document(request, document_id):
         'form': form,
         'document': document,
     })
+
+
+@login_required
+def create_folder(request):
+    if request.method == 'POST':
+        form = FolderForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('home')
+    else:
+        form = FolderForm()
+    return render(request, 'create_folder.html', {'form': form})

--- a/dropbox/settings.py
+++ b/dropbox/settings.py
@@ -123,6 +123,10 @@ STATIC_ROOT = BASE_DIR / 'staticfiles'  # Where Django collects static files
 # Additional WhiteNoise configuration for efficiency
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
+# Authentication
+LOGIN_URL = 'login'
+LOGIN_REDIRECT_URL = 'home'
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 


### PR DESCRIPTION
## Summary
- add a basic Folder model and migrate
- show folders and file details in the upload view
- require login for all views with simple login/logout templates
- update base navbar with authentication links and refresh button
- document features in README

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc7f0af888320bcb27fc9e4b9390b