### PR TITLE
Add metadata search filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Uploaded files are stored on the server and can be browsed from any authenticate
 * **File upload and download** – Upload multiple files and access them from the browser.
 * **Folder organisation** – Create folders and assign uploaded files to them.
 * **Image and video previews** – Thumbnails are generated for images and videos for quick browsing.
-* **Search** – Simple search by file title.
+* **Search** – Search by file title, type and upload date.
 * **Authentication** – Login is required to access any view.
 * **Refresh button** – Quickly reload the page to see new files.
 

--- a/documents/templates/base.html
+++ b/documents/templates/base.html
@@ -21,6 +21,14 @@
   {% endif %}
   <form action="{% url 'search' %}" method="get" class="search-form">
     <input type="text" name="q" placeholder="Search" value="{{ request.GET.q }}">
+    <select name="type">
+      <option value="" {% if not request.GET.type %}selected{% endif %}>All</option>
+      <option value="image" {% if request.GET.type == 'image' %}selected{% endif %}>Images</option>
+      <option value="video" {% if request.GET.type == 'video' %}selected{% endif %}>Videos</option>
+      <option value="other" {% if request.GET.type == 'other' %}selected{% endif %}>Others</option>
+    </select>
+    <input type="date" name="start_date" value="{{ request.GET.start_date }}">
+    <input type="date" name="end_date" value="{{ request.GET.end_date }}">
     <button type="submit">Search</button>
   </form>
   <button onclick="location.reload()">Refresh</button>

--- a/documents/templates/search_results.html
+++ b/documents/templates/search_results.html
@@ -3,6 +3,13 @@
 {% block content %}
 <div class="uploaded-documents">
     <h2>Search results for "{{ query }}"</h2>
+    {% if type or start_date or end_date %}
+        <p>
+        {% if type %}Type: {{ type }} {% endif %}
+        {% if start_date %}From {{ start_date }} {% endif %}
+        {% if end_date %}To {{ end_date }}{% endif %}
+        </p>
+    {% endif %}
     <ul id="myList">
         {% for document in documents %}
         <li data-aos="fade-up" data-aos-duration="800">

--- a/documents/tests.py
+++ b/documents/tests.py
@@ -1,3 +1,52 @@
-from django.test import TestCase
+import tempfile
+from django.urls import reverse
+from django.test import TestCase, override_settings
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils import timezone
+from unittest import mock
 
-# Create your tests here.
+from .models import Document
+
+
+@override_settings(MEDIA_ROOT=tempfile.gettempdir())
+class SearchViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='user', password='pass')
+        self.client.login(username='user', password='pass')
+
+        patcher_img = mock.patch('documents.models.Document.generate_image_thumbnail', lambda self: None)
+        patcher_vid = mock.patch('documents.models.Document.generate_video_thumbnail', lambda self: None)
+        self.addCleanup(patcher_img.stop)
+        self.addCleanup(patcher_vid.stop)
+        patcher_img.start()
+        patcher_vid.start()
+
+        self.img = Document.objects.create(
+            title='photo',
+            file=SimpleUploadedFile('test.jpg', b'1')
+        )
+        self.vid = Document.objects.create(
+            title='video',
+            file=SimpleUploadedFile('video.mp4', b'1')
+        )
+        self.doc = Document.objects.create(
+            title='doc',
+            file=SimpleUploadedFile('notes.txt', b'1')
+        )
+
+        old_date = timezone.now() - timezone.timedelta(days=2)
+        Document.objects.filter(pk=self.doc.pk).update(uploaded_at=old_date)
+        self.doc.refresh_from_db()
+
+    def test_search_by_type_image(self):
+        response = self.client.get(reverse('search'), {'type': 'image'})
+        self.assertContains(response, 'photo')
+        self.assertNotContains(response, 'video')
+
+    def test_search_by_date(self):
+        today = timezone.now().date().isoformat()
+        response = self.client.get(reverse('search'), {'start_date': today})
+        self.assertContains(response, 'photo')
+        self.assertContains(response, 'video')
+        self.assertNotContains(response, 'doc')

--- a/documents/views.py
+++ b/documents/views.py
@@ -82,10 +82,32 @@ def document_detail(request, document_id):
 @login_required
 def search(request):
     query = request.GET.get('q', '')
-    documents = Document.objects.filter(title__icontains=query) if query else []
+    file_type = request.GET.get('type', '')
+    start_date = request.GET.get('start_date')
+    end_date = request.GET.get('end_date')
+
+    documents = Document.objects.all()
+    if query:
+        documents = documents.filter(title__icontains=query)
+
+    if file_type == 'image':
+        documents = documents.filter(file__iregex=r'.*\.(jpg|jpeg|png|gif)$')
+    elif file_type == 'video':
+        documents = documents.filter(file__iregex=r'.*\.(mp4|mov|avi|mkv)$')
+    elif file_type == 'other':
+        documents = documents.exclude(file__iregex=r'.*\.(jpg|jpeg|png|gif|mp4|mov|avi|mkv)$')
+
+    if start_date:
+        documents = documents.filter(uploaded_at__date__gte=start_date)
+    if end_date:
+        documents = documents.filter(uploaded_at__date__lte=end_date)
+
     return render(request, 'search_results.html', {
         'documents': documents,
         'query': query,
+        'type': file_type,
+        'start_date': start_date,
+        'end_date': end_date,
     })
 
 


### PR DESCRIPTION
## Summary
- implement search filters for file type and upload date
- adjust search form to include filter options
- show active filters on search results page
- document metadata search feature
- add basic tests covering new search filters

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686dcbb7b51083209baf6f4d52000fe1