### PR TITLE
Add navigation buttons for viewer

### DIFF
--- a/documents/static/mystyle.css
+++ b/documents/static/mystyle.css
@@ -251,6 +251,7 @@ ul {
 }
 
 .image-container {
+    position: relative;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -264,6 +265,35 @@ ul {
     max-width: 100%; /* Limits the width on all screens */
     height: auto; /* Keeps the aspect ratio intact */
     max-height: 80vh; /* Adjusts the maximum height to avoid overlap with other page elements */
+}
+
+.image-container video {
+    width: 100%;
+    max-width: 100%;
+    max-height: 80vh;
+}
+
+.nav-btn {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(0, 0, 0, 0.3);
+    color: #fff;
+    padding: 10px 15px;
+    border-radius: 50%;
+    text-decoration: none;
+    font-size: 2rem;
+    transition: background 0.3s;
+    z-index: 10;
+}
+.nav-btn:hover {
+    background: rgba(0, 0, 0, 0.6);
+}
+.nav-btn.prev {
+    left: 10px;
+}
+.nav-btn.next {
+    right: 10px;
 }
 
 /* Media query for screens wider than 768px */

--- a/documents/templates/document_detail.html
+++ b/documents/templates/document_detail.html
@@ -3,7 +3,19 @@
 {% block content %}
 
 <div class="image-container">
-    <img src="{{ document.file.url }}" alt="{{ document.title }}">
+    {% if prev_document %}
+        <a href="{% url 'document_detail' prev_document.id %}" class="nav-btn prev">&#10094;</a>
+    {% endif %}
+
+    {% if document.is_video %}
+        <video controls src="{{ document.file.url }}"></video>
+    {% else %}
+        <img src="{{ document.file.url }}" alt="{{ document.title }}">
+    {% endif %}
+
+    {% if next_document %}
+        <a href="{% url 'document_detail' next_document.id %}" class="nav-btn next">&#10095;</a>
+    {% endif %}
 </div>
 <div class="navigation-links">
     <a class="btn" href="{% url 'rename_document' document.id %}">Rename</a>


### PR DESCRIPTION
## Summary
- show previous/next buttons on the document detail page
- support playing videos in the document detail view
- style navigation buttons and video element

## Testing
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686fd235d3808320a08d6191c0de0eea